### PR TITLE
Support scanning for annotations

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,61 @@
 'use strict';
 
+const LOOKUP = new WeakMap();
+
 function getAnnotations(target, type) {
-  const annotations = target.annotations || [];
+  const annotations = LOOKUP.get(target) || [];
   if (type === undefined) return annotations;
   return annotations.filter(function (annotation) {
     return annotation instanceof type;
   });
 }
 
+function scanPrototypeChain(ctor, type, proto, seen) {
+  if (proto === null || proto === Object.prototype) {
+    return [];
+  }
+
+  const own = Object.getOwnPropertyNames(proto)
+    .reduce(function(found, prop) {
+      if (seen.indexOf(prop) !== -1) return found;
+      seen.push(prop);
+
+      const target = proto[prop];
+      if (typeof target !== 'function') return found;
+
+      return found.concat(getAnnotations(target, type).map(function(annotation) {
+        return {
+          annotation: annotation,
+          target: target,
+          ctor: ctor,
+          key: prop
+        };
+      }));
+    }, []);
+
+  return scanPrototypeChain(ctor, type, Object.getPrototypeOf(proto), seen)
+    .concat(own);
+}
+
+function scanFunction(target, type) {
+  return getAnnotations(target, type)
+    .map(function (annotation) {
+      return { annotation: annotation, target: target };
+    });
+}
+
 function scanAnnotations(target, type) {
-  return getAnnotations(target, type);
+  if (typeof target === 'function') {
+    return scanFunction(target, type)
+      .concat(scanPrototypeChain(target, type, target.prototype, [ 'constructor' ]));
+  }
+  return [];
 }
 
 function pushAnnotation(target, annotation) {
   if (typeof target === 'function') {
-    target.annotations = target.annotations || [];
-    target.annotations.push(annotation);
+    if (!LOOKUP.has(target)) LOOKUP.set(target, []);
+    LOOKUP.get(target).push(annotation);
   }
   return target;
 }

--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ function getAnnotations(target, type) {
   });
 }
 
+function scanAnnotations(target, type) {
+  return getAnnotations(target, type);
+}
+
 function pushAnnotation(target, annotation) {
   if (typeof target === 'function') {
     target.annotations = target.annotations || [];
@@ -37,4 +41,6 @@ exports.create = createAnnotation;
 exports.createAnnotation = createAnnotation;
 exports.get = getAnnotations;
 exports.getAnnotations = getAnnotations;
+exports.scan = scanAnnotations;
+exports.scanAnnotations = scanAnnotations;
 exports['default'] = exports;

--- a/test/scan.js
+++ b/test/scan.js
@@ -17,8 +17,8 @@ function Other() {
 test('scan a function without annotations', function(t) {
   function f() {}
 
-  const annotations = Annotation.scan(f);
-  t.deepEqual(annotations, [], 'No annotations expected');
+  const results = Annotation.scan(f);
+  t.deepEqual(results, [], 'No annotations expected');
 
   t.end();
 });
@@ -28,9 +28,11 @@ test('scan a function with annotation', function(t) {
   Simple(f);
   function f() {}
 
-  const annotations = Annotation.scan(f);
-  t.ok(annotations[0] instanceof Other, 'Other is found');
-  t.ok(annotations[1] instanceof Simple, 'Simple is found');
+  const results = Annotation.scan(f);
+  t.ok(results[0].annotation instanceof Other, 'Other is found');
+  t.ok(results[1].annotation instanceof Simple, 'Simple is found');
+  t.equal(results[0].target, f, 'Returns the target');
+  t.equal(results[1].target, f, 'Returns the target');
 
   t.end();
 });
@@ -40,9 +42,52 @@ test('scan a function, filtered by type', function(t) {
   Simple(f);
   function f() {}
 
-  const annotations = Annotation.scan(f, Simple);
-  t.equal(annotations.length, 1, 'Finds only one annotation');
-  t.ok(annotations[0] instanceof Simple, 'Finds the right annotation');
+  const results = Annotation.scan(f, Simple);
+  t.equal(results.length, 1, 'Finds only one annotation');
+  t.ok(results[0].annotation instanceof Simple, 'Finds the right annotation');
+  t.equal(results[0].target, f, 'Returns the target');
+
+  t.end();
+});
+
+test('scan a class', function(t) {
+  class Base {
+    a() {} // overridden
+    b() {} // visible
+  }
+  Simple(Base);
+  Simple(Base.prototype.a);
+  Simple(Base.prototype.b);
+  Other(Base.prototype.b);
+
+  class Derived extends Base {
+    a() {}
+    c() {} // only in derived
+  }
+  Other(Derived);
+  Simple(Derived);
+  Simple(Derived.prototype.a);
+  Simple(Derived.prototype.c);
+
+  const results = Annotation.scan(Derived, Simple);
+  t.equal(results.length, 4, '1 on class + 3 on methods = 4 found');
+  t.equal(results[0].target, Derived, 'Class itself comes first');
+  t.equal(results[1].target, Base.prototype.b, 'Then Base method b');
+  t.equal(results[2].target, Derived.prototype.a, 'Then Derived method a');
+  t.equal(results[3].target, Derived.prototype.c, 'Then Derived method c');
+
+  t.equal(results[1].ctor, Derived, 'Includes constructor for methods (b)');
+  t.equal(results[1].key, 'b', 'Includes property key for methods (b)');
+
+  t.equal(results[2].ctor, Derived, 'Includes constructor for methods (a)');
+  t.equal(results[2].key, 'a', 'Includes property key for methods (a)');
+
+  t.equal(results[3].ctor, Derived, 'Includes constructor for methods (c)');
+  t.equal(results[3].key, 'c', 'Includes property key for methods (c)');
+
+  results.forEach(function(r) {
+    t.ok(r.annotation instanceof Simple, 'Only returns Simple annotations');
+  });
 
   t.end();
 });

--- a/test/scan.js
+++ b/test/scan.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const test = require('tape');
+
+const Annotation = require('../');
+
+function Simple() {
+  return Annotation.create(Simple.prototype)
+    .apply(null, arguments);
+}
+
+function Other() {
+  return Annotation.create(Other.prototype)
+    .apply(null, arguments);
+}
+
+test('scan a function without annotations', function(t) {
+  function f() {}
+
+  const annotations = Annotation.scan(f);
+  t.deepEqual(annotations, [], 'No annotations expected');
+
+  t.end();
+});
+
+test('scan a function with annotation', function(t) {
+  Other(f);
+  Simple(f);
+  function f() {}
+
+  const annotations = Annotation.scan(f);
+  t.ok(annotations[0] instanceof Other, 'Other is found');
+  t.ok(annotations[1] instanceof Simple, 'Simple is found');
+
+  t.end();
+});
+
+test('scan a function, filtered by type', function(t) {
+  Other(f);
+  Simple(f);
+  function f() {}
+
+  const annotations = Annotation.scan(f, Simple);
+  t.equal(annotations.length, 1, 'Finds only one annotation');
+  t.ok(annotations[0] instanceof Simple, 'Finds the right annotation');
+
+  t.end();
+});


### PR DESCRIPTION
- Accepts either a function or a class
- Will include annotations on the function and on all methods

Switches to `WeakMap` because inheritance messes with properties on the base class.
