### PR TITLE
Support for scanning objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,16 @@ function scanAnnotations(target, type) {
   if (typeof target === 'function') {
     return scanFunction(target, type)
       .concat(scanPrototypeChain(target, type, target.prototype, [ 'constructor' ]));
+  } else if (target !== null && typeof target === 'object') {
+    return scanPrototypeChain(target, type, target, [ 'constructor' ])
+      .map(function(result) {
+        return {
+          annotation: result.annotation,
+          target: result.target,
+          ctx: result.ctor,
+          key: result.key
+        };
+      });
   }
   return [];
 }

--- a/test/scan.js
+++ b/test/scan.js
@@ -50,6 +50,42 @@ test('scan a function, filtered by type', function(t) {
   t.end();
 });
 
+test('scan an instance', function(t) {
+  class Base {
+    a() {} // overridden
+    b() {} // visible
+  }
+  Simple(Base);
+  Simple(Base.prototype.a);
+  Simple(Base.prototype.b);
+  Other(Base.prototype.b);
+
+  class Derived extends Base {
+    a() {}
+    c() {} // only in derived
+  }
+  Other(Derived);
+  Simple(Derived);
+  Simple(Derived.prototype.a);
+  Simple(Derived.prototype.c);
+
+  const obj = new Derived();
+  const results = Annotation.scan(obj, Simple);
+  t.equal(results.length, 3, '3 on methods');
+
+  t.equal(results[0].ctx, obj, 'Includes context objects (b)');
+  t.equal(results[0].key, 'b', 'Includes property key for methods (b)');
+  t.equal(results[0].target, obj.b, 'Includes method itself');
+
+  t.equal(results[1].ctx, obj, 'Includes context objects (a)');
+  t.equal(results[1].key, 'a', 'Includes property key for methods (a)');
+
+  t.equal(results[2].ctx, obj, 'Includes context objects (c)');
+  t.equal(results[2].key, 'c', 'Includes property key for methods (c)');
+
+  t.end();
+});
+
 test('scan a class', function(t) {
   class Base {
     a() {} // overridden


### PR DESCRIPTION
This means that there's now three separate cases:
- Has `ctor`: It's a method on a class
- Has `ctx`: It's a method on an object
- Just `target`: It's a simple function
